### PR TITLE
Fix duplicate command on nvimrc

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -13,7 +13,6 @@ set smartindent
 " Search options
 set ignorecase
 set smartcase
-set smartcase
 
 " Performance options
 set lazyredraw


### PR DESCRIPTION
Correct me if I'm wrong, but I don't think setting `smartcase` twice was
intentional.